### PR TITLE
Add --no-tablespaces option to mysqldump command.

### DIFF
--- a/bin/db-pull.sh
+++ b/bin/db-pull.sh
@@ -20,9 +20,9 @@ echo $(ls -la local.sql)
 
 echo "===== Exporting remote database ====="
 if [ -n "${SSH_CONFIG}" ]; then
-  ssh ${SSH_CONFIG} "mysqldump --host=${DB_HOST} --user=${DB_USER} --password=\"${DB_PASSWORD}\" --default-character-set=utf8 ${DB_NAME}" > remote.sql
+  ssh ${SSH_CONFIG} "mysqldump --host=${DB_HOST} --user=${DB_USER} --password=\"${DB_PASSWORD}\" --default-character-set=utf8 --no-tablespaces ${DB_NAME}" > remote.sql
 else
-  ssh ${SSH_USER}@${SSH_HOST} -p ${SSH_PORT} "mysqldump --host=${DB_HOST} --user=${DB_USER} --password=\"${DB_PASSWORD}\" --default-character-set=utf8 ${DB_NAME}" > remote.sql
+  ssh ${SSH_USER}@${SSH_HOST} -p ${SSH_PORT} "mysqldump --host=${DB_HOST} --user=${DB_USER} --password=\"${DB_PASSWORD}\" --default-character-set=utf8 --no-tablespaces ${DB_NAME}" > remote.sql
 fi
 echo $(ls -la remote.sql)
 


### PR DESCRIPTION
https://dev.mysql.com/doc/relnotes/mysql/5.7/en/news-5-7-31.html#mysqld-5-7-31-security
`Access to the INFORMATION_SCHEMA.FILES table now requires the PROCESS privilege.`